### PR TITLE
Add support for libseat session backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev libdbus-1-dev libsystemd-dev \
-            libxkbcommon-dev libinput-dev libwayland-server0
+            libxkbcommon-dev libinput-dev libwayland-dev
       - uses: actions/checkout@v2
       - name: Stable
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libudev-dev libdbus-1-dev libsystemd-dev libxkbcommon-dev libinput-dev
+          sudo apt-get install libudev-dev libdbus-1-dev libsystemd-dev \
+            libxkbcommon-dev libinput-dev libwayland-server0
       - uses: actions/checkout@v2
       - name: Stable
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Stable
         run: cargo test
+      - name: Stable no-features
+        run: cargo build --no-default-features
       - name: Oldstable
         run: |
           oldstable=$(cat Cargo.toml | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,16 +392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4addc164932852d066774c405dbbdb7914742d2b39e39e1a7ca949c856d054d1"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,26 +414,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "input"
@@ -508,6 +503,24 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
+
+[[package]]
+name = "libseat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ad314f75263a2135fb09bf96af96eb573582a4a36f6ef9bfdb5f7cec7686fc"
+dependencies = [
+ "cc",
+ "errno",
+ "libseat-sys",
+ "slog",
+]
+
+[[package]]
+name = "libseat-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72fcf823d256aa619f93c81bc192e6dfbf051835990e28238cd14ad81136397"
 
 [[package]]
 name = "libudev-sys"
@@ -934,11 +947,11 @@ dependencies = [
  "drm-fourcc",
  "gbm",
  "gl_generator",
- "indexmap",
  "input",
  "lazy_static",
  "libc",
  "libloading",
+ "libseat",
  "nix",
  "once_cell",
  "pkg-config",
@@ -956,7 +969,6 @@ dependencies = [
  "wayland-server",
  "wayland-sys",
  "winit",
- "x11rb",
  "xkbcommon",
 ]
 
@@ -1253,15 +1265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,18 +1312,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "x11rb"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e99be55648b3ae2a52342f9a870c0e138709a3493261ce9b469afe6e4df6d8a"
-dependencies = [
- "gethostname",
- "nix",
- "winapi",
- "winapi-wsapoll",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,30 @@ rust-version = "1.59.0"
 license = "GPL-3.0"
 edition = "2021"
 
+[dependencies.smithay]
+git = "https://github.com/chrisduerr/smithay" 
+rev = "5129920247146d4d626f675f31603752700ef8e7"
+default-features = false
+features = [
+    "use_system_lib",
+    "backend_drm",
+    "backend_gbm",
+    "backend_libinput",
+    "backend_udev",
+    "backend_session",
+    "renderer_gl",
+    "renderer_multi",
+    "slog-stdlog"
+]
+
+
 [dependencies]
-smithay = { git = "https://github.com/chrisduerr/smithay", rev = "5129920247146d4d626f675f31603752700ef8e7", features = ["use_system_lib"] }
 calloop = "0.9.3"
 libc = "0.2.123"
 udev = "0.6.2"
+
+[features]
+default = [ "winit", "systemd" ]
+winit = ["smithay/backend_winit"]
+libseat = ["smithay/backend_session_libseat"]
+systemd = ["smithay/backend_session_logind"]

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,6 +9,7 @@ use smithay::backend::input::{
     ButtonState, Event, InputBackend, InputEvent, KeyState, KeyboardKeyEvent, MouseButton,
     PointerButtonEvent, PositionEvent, TouchEvent as _, TouchSlot,
 };
+#[cfg(feature = "winit")]
 use smithay::backend::winit::WinitEvent;
 use smithay::utils::{Logical, Point, Rectangle, Size};
 use smithay::wayland::seat::{keysyms, FilterResult, TouchHandle};
@@ -232,6 +233,7 @@ impl<B: Backend> Catacomb<B> {
     }
 
     /// Process winit-specific input events.
+    #[cfg(feature = "winit")]
     pub fn handle_winit_input(&mut self, event: WinitEvent) {
         match event {
             // Toggle between portrait/landscape based on window size.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod overview;
 mod shell;
 mod udev;
 mod window;
+#[cfg(feature = "winit")]
 mod winit;
 
 fn main() {
@@ -21,6 +22,7 @@ fn main() {
     if env::var_os("DISPLAY").is_none() && env::var_os("WAYLAND_DISPLAY").is_none() {
         udev::run();
     } else {
+        #[cfg(feature = "winit")]
         winit::run();
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -142,6 +142,7 @@ impl Output {
     }
 
     /// Resize the output.
+    #[cfg(feature = "winit")]
     pub fn resize(&mut self, size: Size<i32, Physical>) {
         self.mode.size = size;
     }


### PR DESCRIPTION
This commit adds build time features to control the session backend. As
well as adds an option to opt-out from winit backend to reduce build
time.