### PR TITLE
Apply mount_matrix on accelerometer results

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,7 +1,8 @@
 //! Extension's to Smithay's geometry module.
 
+use std::error::Error;
 use std::str::FromStr;
-use std::{cmp, error, fmt, ops};
+use std::{cmp, fmt, ops};
 
 use smithay::utils::{Point, Size};
 
@@ -23,10 +24,10 @@ impl fmt::Display for FromVecError {
     }
 }
 
-impl error::Error for FromVecError {}
+impl Error for FromVecError {}
 
 impl<T: Copy> TryFrom<Vec<T>> for Matrix3x3<T> {
-    type Error = Box<dyn error::Error>;
+    type Error = Box<dyn Error>;
 
     fn try_from(storage: Vec<T>) -> Result<Self, Self::Error> {
         if storage.len() != 9 {
@@ -37,13 +38,13 @@ impl<T: Copy> TryFrom<Vec<T>> for Matrix3x3<T> {
     }
 }
 
-impl ops::Mul<&Matrix3x3<f32>> for Vector3D<f32> {
+impl ops::Mul<Vector3D<f32>> for &Matrix3x3<f32> {
     type Output = Vector3D<f32>;
 
-    fn mul(self, rhs: &Matrix3x3<f32>) -> Self::Output {
-        let x = rhs.storage[0] * self.x + rhs.storage[3] * self.y + rhs.storage[6] * self.z;
-        let y = rhs.storage[1] * self.x + rhs.storage[4] * self.y + rhs.storage[7] * self.z;
-        let z = rhs.storage[2] * self.x + rhs.storage[5] * self.y + rhs.storage[8] * self.z;
+    fn mul(self, rhs: Vector3D<f32>) -> Self::Output {
+        let x = self.storage[0] * rhs.x + self.storage[1] * rhs.y + self.storage[2] * rhs.z;
+        let y = self.storage[3] * rhs.x + self.storage[4] * rhs.y + self.storage[5] * rhs.z;
+        let z = self.storage[6] * rhs.x + self.storage[7] * rhs.y + self.storage[8] * rhs.z;
         Self::Output { x, y, z }
     }
 }
@@ -51,9 +52,9 @@ impl ops::Mul<&Matrix3x3<f32>> for Vector3D<f32> {
 // The accepted formats is is 0, 0, 0; 0, 0, 0; 0, 0, 0.
 impl<T: FromStr + Copy> FromStr for Matrix3x3<T>
 where
-    <T as FromStr>::Err: std::error::Error + 'static,
+    <T as FromStr>::Err: Error + 'static,
 {
-    type Err = Box<dyn error::Error>;
+    type Err = Box<dyn Error>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let rows = s

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -17,8 +17,7 @@ impl<T: Copy> TryFrom<Vec<T>> for Matrix3x3<T> {
     fn try_from(storage: Vec<T>) -> Result<Self, Self::Error> {
         if storage.len() != 9 {
             let error = format!(
-                "Mismatched size when createing Matrix3x3 from Vec, expected {} got {}",
-                9,
+                "Mismatched size when creating Matrix3x3 from Vec, expected length 9, got {}",
                 storage.len()
             );
             Err(error.into())
@@ -39,7 +38,7 @@ impl ops::Mul<Vector3D<f32>> for &Matrix3x3<f32> {
     }
 }
 
-// The accepted formats is is 0, 0, 0; 0, 0, 0; 0, 0, 0.
+// The expected format is "0, 0, 0; 0, 0, 0; 0, 0, 0".
 impl<T: FromStr + Copy> FromStr for Matrix3x3<T>
 where
     <T as FromStr>::Err: Error + 'static,
@@ -166,12 +165,10 @@ mod test {
             Matrix3x3::<i32>::from_str(matrix).unwrap().storage
         );
 
-        let error =
-            String::from("Mismatched size when createing Matrix3x3 from Vec, expected 9 got 3");
         let matrix = "1, 0, 0, 0, 1, 0, 0, 0, 1";
-        assert_eq!(&error, &Matrix3x3::<i32>::from_str(matrix).err().unwrap().to_string());
+        assert!(Matrix3x3::<i32>::from_str(matrix).is_err());
 
         let matrix = "1; 0; 0; 0; 1; 0; 0; 0; 1;";
-        assert_eq!(&error, &Matrix3x3::<i32>::from_str(matrix).err().unwrap().to_string());
+        assert!(Matrix3x3::<i32>::from_str(matrix).is_err());
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 use std::str::FromStr;
-use std::{cmp, fmt, ops};
+use std::{cmp, ops};
 
 use smithay::utils::{Point, Size};
 
@@ -11,27 +11,17 @@ pub struct Matrix3x3<T: Copy> {
     storage: Vec<T>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct FromVecError(usize, usize);
-
-impl fmt::Display for FromVecError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Mismatched size when createing object from vector, expected {} got {}",
-            self.0, self.1
-        )
-    }
-}
-
-impl Error for FromVecError {}
-
 impl<T: Copy> TryFrom<Vec<T>> for Matrix3x3<T> {
     type Error = Box<dyn Error>;
 
     fn try_from(storage: Vec<T>) -> Result<Self, Self::Error> {
         if storage.len() != 9 {
-            Err(Box::new(FromVecError(9, storage.len())))
+            let error = format!(
+                "Mismatched size when createing Matrix3x3 from Vec, expected {} got {}",
+                9,
+                storage.len()
+            );
+            Err(error.into())
         } else {
             Ok(Self { storage })
         }
@@ -72,13 +62,13 @@ where
 
 /// A point in the 3 dimensional space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub struct Vector3D<T: Copy> {
+pub struct Vector3D<T> {
     pub x: T,
     pub y: T,
     pub z: T,
 }
 
-impl<T: Copy> Vector3D<T> {
+impl<T> Vector3D<T> {
     #[inline]
     pub fn new(x: T, y: T, z: T) -> Self {
         Self { x, y, z }
@@ -176,24 +166,12 @@ mod test {
             Matrix3x3::<i32>::from_str(matrix).unwrap().storage
         );
 
+        let error =
+            String::from("Mismatched size when createing Matrix3x3 from Vec, expected 9 got 3");
         let matrix = "1, 0, 0, 0, 1, 0, 0, 0, 1";
-        assert_eq!(
-            &FromVecError(9, 3),
-            Matrix3x3::<i32>::from_str(matrix)
-                .err()
-                .unwrap()
-                .downcast_ref::<FromVecError>()
-                .unwrap()
-        );
+        assert_eq!(&error, &Matrix3x3::<i32>::from_str(matrix).err().unwrap().to_string());
 
         let matrix = "1; 0; 0; 0; 1; 0; 0; 0; 1;";
-        assert_eq!(
-            &FromVecError(9, 3),
-            Matrix3x3::<i32>::from_str(matrix)
-                .err()
-                .unwrap()
-                .downcast_ref::<FromVecError>()
-                .unwrap()
-        );
+        assert_eq!(&error, &Matrix3x3::<i32>::from_str(matrix).err().unwrap().to_string());
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,8 +1,113 @@
 //! Extension's to Smithay's geometry module.
 
-use std::cmp;
+use std::str::FromStr;
+use std::{cmp, error, fmt, ops};
 
 use smithay::utils::{Point, Size};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Matrix3x3<T: Copy> {
+    storage: Vec<T>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct FromVecError(usize, usize);
+
+impl fmt::Display for FromVecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Mismatched size when createing object from vector, expected {} got {}",
+            self.0, self.1
+        )
+    }
+}
+
+impl error::Error for FromVecError {}
+
+impl<T: Copy> TryFrom<Vec<T>> for Matrix3x3<T> {
+    type Error = Box<dyn error::Error>;
+
+    fn try_from(storage: Vec<T>) -> Result<Self, Self::Error> {
+        if storage.len() != 9 {
+            Err(Box::new(FromVecError(9, storage.len())))
+        } else {
+            Ok(Self { storage })
+        }
+    }
+}
+
+impl ops::Mul<&Matrix3x3<f32>> for Vector3D<f32> {
+    type Output = Vector3D<f32>;
+
+    fn mul(self, rhs: &Matrix3x3<f32>) -> Self::Output {
+        let x = rhs.storage[0] * self.x + rhs.storage[3] * self.y + rhs.storage[6] * self.z;
+        let y = rhs.storage[1] * self.x + rhs.storage[4] * self.y + rhs.storage[7] * self.z;
+        let z = rhs.storage[2] * self.x + rhs.storage[5] * self.y + rhs.storage[8] * self.z;
+        Self::Output { x, y, z }
+    }
+}
+
+// The accepted formats is is 0, 0, 0; 0, 0, 0; 0, 0, 0.
+impl<T: FromStr + Copy> FromStr for Matrix3x3<T>
+where
+    <T as FromStr>::Err: std::error::Error + 'static,
+{
+    type Err = Box<dyn error::Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rows = s
+            .split(';')
+            // Ensure that we process only 3 rows.
+            .take(3)
+            // Take only 3 element from each row.
+            .flat_map(|row| row.split(',').take(3))
+            .map(|ch| T::from_str(ch.trim()))
+            .collect::<Result<Vec<T>, _>>()?;
+
+        Self::try_from(rows)
+    }
+}
+
+/// A point in the 3 dimensional space.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Vector3D<T: Copy> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
+impl<T: Copy> Vector3D<T> {
+    #[inline]
+    pub fn new(x: T, y: T, z: T) -> Self {
+        Self { x, y, z }
+    }
+}
+
+impl Vector for Vector3D<f32> {
+    fn scale(&self, scale: f64) -> Self {
+        let x = scale as f32 * self.x;
+        let y = scale as f32 * self.y;
+        let z = scale as f32 * self.z;
+        Self { x, y, z }
+    }
+
+    fn min(&self, other: impl Into<Self>) -> Self {
+        let other = other.into();
+        let x = self.x.min(other.x);
+        let y = self.y.min(other.y);
+        let z = self.z.min(other.z);
+        Self { x, y, z }
+    }
+
+    fn max(&self, other: impl Into<Self>) -> Self {
+        let other = other.into();
+        let x = self.x.max(other.x);
+        let y = self.y.max(other.y);
+        let z = self.z.max(other.z);
+        Self { x, y, z }
+    }
+}
 
 pub trait Vector: Sized {
     /// Scale the size by a scaling factor.
@@ -55,5 +160,39 @@ where
         let tuple = self.as_vector();
         let other = other.into().as_vector();
         Self::from((cmp::max(tuple.0, other.0), cmp::max(tuple.1, other.1)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_matrix() {
+        let matrix = "1, 0, 0; 0, 1, 0; 0, 0, 1";
+        assert_eq!(
+            vec![1, 0, 0, 0, 1, 0, 0, 0, 1],
+            Matrix3x3::<i32>::from_str(matrix).unwrap().storage
+        );
+
+        let matrix = "1, 0, 0, 0, 1, 0, 0, 0, 1";
+        assert_eq!(
+            &FromVecError(9, 3),
+            Matrix3x3::<i32>::from_str(matrix)
+                .err()
+                .unwrap()
+                .downcast_ref::<FromVecError>()
+                .unwrap()
+        );
+
+        let matrix = "1; 0; 0; 0; 1; 0; 0; 0; 1;";
+        assert_eq!(
+            &FromVecError(9, 3),
+            Matrix3x3::<i32>::from_str(matrix)
+                .err()
+                .unwrap()
+                .downcast_ref::<FromVecError>()
+                .unwrap()
+        );
     }
 }

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -106,8 +106,8 @@ impl SensorAccelerometer {
         //
         // This will return the angle between the orientation axis and the
         // position. So for example when the portrait_angle is zero it means
-        // that device is vertical, however to determine whether it's upside
-        // down or vice-versa we must look at the angle to landscape.
+        // that the device is vertical, however to determine whether it's
+        // upside down or not we must look at the angle to landscape.
         let radians_to_degrees = 180. / f32::consts::PI;
         let portrait_angle = (x.atan2((y * y + z * z).sqrt()) * radians_to_degrees).round();
         let landscape_angle = (y.atan2((x * x + z * z).sqrt()) * radians_to_degrees).round();

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -11,6 +11,7 @@ use smithay::utils::Transform;
 use udev::{Device, Enumerator};
 
 use crate::catacomb::Catacomb;
+use crate::geometry::{Matrix3x3, Vector, Vector3D};
 
 /// Orientation change poll rate.
 const POLL_RATE: Duration = Duration::from_millis(500);
@@ -59,6 +60,7 @@ impl AccelerometerSource for Accelerometer {
 pub struct SensorAccelerometer {
     syspath: PathBuf,
     last: Option<Orientation>,
+    accel_mount_matrix: Matrix3x3<f32>,
 }
 
 impl SensorAccelerometer {
@@ -69,8 +71,15 @@ impl SensorAccelerometer {
         enumerator.match_subsystem("iio").ok()?;
 
         let mut devices = enumerator.scan_devices().ok()?;
-        let accel = devices.find(|device| device.attribute_value("in_accel_x_raw").is_some());
-        accel.map(|accel| Self { syspath: accel.syspath().to_path_buf(), last: None })
+        let accel = devices.find(|device| device.attribute_value("in_accel_x_raw").is_some())?;
+
+        // Read the mount_matrix values.
+        let accel_mount_matrix = udev_attribute::<Matrix3x3<f32>>(&accel, "in_mount_matrix")
+            .or_else(|| udev_attribute::<Matrix3x3<f32>>(&accel, "in_accel_mount_matrix"))?;
+
+        let syspath = accel.syspath().to_path_buf();
+
+        Some(Self { syspath, last: None, accel_mount_matrix })
     }
 
     /// Check device orientation.
@@ -80,42 +89,50 @@ impl SensorAccelerometer {
     fn orientation(&self) -> Option<Orientation> {
         // Read data from sensor.
         let device = Device::from_syspath(&self.syspath).ok()?;
-        let mut x = udev_attribute::<i32>(&device, "in_accel_x_raw")? as f32;
-        let mut y = udev_attribute::<i32>(&device, "in_accel_y_raw")? as f32;
-        let mut z = udev_attribute::<i32>(&device, "in_accel_z_raw")? as f32;
-        let scale: f32 = udev_attribute(&device, "in_accel_scale")?;
+
+        let x = udev_attribute::<i32>(&device, "in_accel_x_raw")? as f32;
+        let y = udev_attribute::<i32>(&device, "in_accel_y_raw")? as f32;
+        let z = udev_attribute::<i32>(&device, "in_accel_z_raw")? as f32;
+
+        // Apply acceleration matrix.
+        let accel_point = Vector3D::new(x, y, z) * &self.accel_mount_matrix;
+
+        let scale = udev_attribute::<f32>(&device, "in_accel_scale")? as f64;
 
         // Apply scale to get to m/s², then convert 1G ~= 256 for the algorithm to work.
-        x = x * scale * 256. / 9.81;
-        y = y * scale * 256. / 9.81;
-        z = z * scale * 256. / 9.81;
+        let Vector3D { x, y, z } = accel_point.scale(scale * 256. / 9.81);
 
         // Compute angle to landscape/portrait mode.
         //
-        // This will return 90° for landscape/portrait when the modes are fully active
-        // and transition to -90° for the inverse.
+        // This will return the angle between the orientation axis and the position. So
+        // for example when the portrait_angle is zero it means that device is
+        // vertical, however to determine whether it's upside down or vise-versa
+        // we must look at the angle to landspace.
         let radians_to_degrees = 180. / f32::consts::PI;
-        let portrait = (x.atan2((y * y + z * z).sqrt()) * radians_to_degrees).round();
-        let landscape = (y.atan2((x * x + z * z).sqrt()) * radians_to_degrees).round();
-        let portrait_abs = portrait.abs();
-        let landscape_abs = landscape.abs();
+        let portrait_angle = (x.atan2((y * y + z * z).sqrt()) * radians_to_degrees).round();
+        let landscape_angle = (y.atan2((x * x + z * z).sqrt()) * radians_to_degrees).round();
+
+        let portrait_angle_abs = portrait_angle.abs();
+        let landscape_angle_abs = landscape_angle.abs();
 
         // Deadzone to avoid flickering between orientation.
-        if portrait_abs + DEADZONE > THRESHOLD && landscape_abs + DEADZONE > THRESHOLD {
+        if portrait_angle_abs + DEADZONE > THRESHOLD && landscape_angle_abs + DEADZONE > THRESHOLD {
             return None;
         }
 
-        let orientation = if portrait_abs > THRESHOLD {
-            if portrait > 0. {
-                Orientation::Portrait
-            } else {
-                Orientation::InversePortrait
-            }
-        } else if landscape_abs > THRESHOLD {
-            if landscape > 0. {
+        // Check if we're far enough from portrait axis to pick landscape mode.
+        let orientation = if portrait_angle_abs > THRESHOLD {
+            if portrait_angle > 0. {
                 Orientation::InverseLandscape
             } else {
                 Orientation::Landscape
+            }
+        // Ditto for landspace axis.
+        } else if landscape_angle_abs > THRESHOLD {
+            if landscape_angle > 0. {
+                Orientation::InversePortrait
+            } else {
+                Orientation::Portrait
             }
         } else {
             // No orientation is present when parallel to the ground.

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -104,10 +104,10 @@ impl SensorAccelerometer {
 
         // Compute angle to landscape/portrait mode.
         //
-        // This will return the angle between the orientation axis and the position. So
-        // for example when the portrait_angle is zero it means that device is
-        // vertical, however to determine whether it's upside down or vise-versa
-        // we must look at the angle to landscape.
+        // This will return the angle between the orientation axis and the
+        // position. So for example when the portrait_angle is zero it means
+        // that device is vertical, however to determine whether it's upside
+        // down or vice-versa we must look at the angle to landscape.
         let radians_to_degrees = 180. / f32::consts::PI;
         let portrait_angle = (x.atan2((y * y + z * z).sqrt()) * radians_to_degrees).round();
         let landscape_angle = (y.atan2((x * x + z * z).sqrt()) * radians_to_degrees).round();

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -95,7 +95,7 @@ impl SensorAccelerometer {
         let z = udev_attribute::<i32>(&device, "in_accel_z_raw")? as f32;
 
         // Apply acceleration matrix.
-        let accel_point = Vector3D::new(x, y, z) * &self.accel_mount_matrix;
+        let accel_point = &self.accel_mount_matrix * Vector3D::new(x, y, z);
 
         let scale = udev_attribute::<f32>(&device, "in_accel_scale")? as f64;
 
@@ -107,7 +107,7 @@ impl SensorAccelerometer {
         // This will return the angle between the orientation axis and the position. So
         // for example when the portrait_angle is zero it means that device is
         // vertical, however to determine whether it's upside down or vise-versa
-        // we must look at the angle to landspace.
+        // we must look at the angle to landscape.
         let radians_to_degrees = 180. / f32::consts::PI;
         let portrait_angle = (x.atan2((y * y + z * z).sqrt()) * radians_to_degrees).round();
         let landscape_angle = (y.atan2((x * x + z * z).sqrt()) * radians_to_degrees).round();


### PR DESCRIPTION
Orientation handling was not applying mount_matrix leading to
broken rotatation on devices that don't have an identity matrix
as their acceleration matrix.